### PR TITLE
[fix] function local:groups

### DIFF
--- a/src/main/xar-resources/modules/users.xql
+++ b/src/main/xar-resources/modules/users.xql
@@ -35,16 +35,14 @@ declare function local:find-users() {
 declare function local:groups() {
     let $user := local:real-user()
     let $admins := sm:get-group-members($config:admin-group)
-    let $groups := sm:list-groups()[starts-with(., "wiki.")]
+    let $wiki-groups := sm:list-groups()[starts-with(., "wiki.")]
     let $groups :=
         if ($user = $admins) then
-            $groups
+            $wiki-groups
         else
-            filter(function($group) {
-                    $user = sm:get-group-managers($group)
-                },
-                $groups
-            )
+            filter($wiki-groups, function($group) {
+                $user = sm:get-group-managers($group)
+            })
     return
         <groups>
         {


### PR DESCRIPTION
fixes #75

- use correct order of arguments for fn:filter
- rename ambiguous variable $groups to $wiki-groups