### PR TITLE
Fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,8 +179,26 @@
 
     <repositories>
         <repository>
-            <id>exist</id>
-            <url>http://repo.exist-db.org/repository/exist-db</url>
+            <id>exist-db-snapshots</id>
+            <name>Evolved Binary - eXist-db Snapshots</name>
+            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>exist-db</id>
+            <name>Evolved Binary - eXist-db Releases</name>
+            <url>https://repo.evolvedbinary.com/repository/exist-db/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
 

--- a/src/main/xar-resources/modules/acl.xql
+++ b/src/main/xar-resources/modules/acl.xql
@@ -3,7 +3,7 @@ xquery version "3.0";
 module namespace acl="http://atomic.exist-db.org/xquery/atomic/acl";
 
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
-import module namespace templates="http://exist-db.org/xquery/templates";
+import module namespace templates="http://exist-db.org/xquery/html-templating";
 
 declare %private function acl:set-perm($value as item()?, $flag as xs:string) {
     if ($value) then $flag else "-"

--- a/src/main/xar-resources/modules/app.xql
+++ b/src/main/xar-resources/modules/app.xql
@@ -3,7 +3,7 @@ xquery version "3.0";
 module namespace app="http://exist-db.org/xquery/app";
 
 import module namespace atomic="http://atomic.exist-db.org/xquery/atomic" at "atomic.xql";
-import module namespace templates="http://exist-db.org/xquery/templates";
+import module namespace templates="http://exist-db.org/xquery/html-templating";
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
 import module namespace html2wiki="http://atomic.exist-db.org/xquery/html2wiki" at "html2wiki.xql";
 import module namespace acl="http://atomic.exist-db.org/xquery/atomic/acl" at "acl.xql";
@@ -420,7 +420,7 @@ declare function app:edit-source($node as node(), $model as map(*)) {
                 util:collection-name($model("entry")) || "/" || $href
             else
                 document-uri(root($model("entry")))
-        let $eXideLink := templates:link-to-app("http://exist-db.org/apps/eXide", "index.html")
+        let $eXideLink := $model?eXide || "/index.html?open=" || $source
         return
             <a class="eXide-open" href="{$eXideLink}" target="eXide" data-exide-open="{$source}"
                     title="Opens the code in eXide in new tab or existing tab if it is already open.">

--- a/src/main/xar-resources/modules/app.xql
+++ b/src/main/xar-resources/modules/app.xql
@@ -59,8 +59,8 @@ declare function app:get-or-create-feed($node as node(), $model as map(*), $crea
 declare
     %templates:wrap
     %templates:default("start", 1)
-function app:entries($node as node(), $model as map(*), $count as xs:string?, $id as xs:string?, $wiki-id as xs:string?,
-    $start as xs:int) {
+function app:entries($node as node(), $model as map(*), $count as xs:string?, $id as xs:string?, $wiki-id as xs:string?, $start as xs:int?) {
+    let $start := ($start, 0)[1]
     let $feed := $model("feed")
     let $allEntries := config:get-entries($feed, $id, $wiki-id)
     return

--- a/src/main/xar-resources/modules/atomic.xql
+++ b/src/main/xar-resources/modules/atomic.xql
@@ -2,7 +2,7 @@ xquery version "3.0";
 
 module namespace atomic="http://atomic.exist-db.org/xquery/atomic";
 
-import module namespace md="http://exist-db.org/xquery/markdown";
+import module namespace markdown="http://exist-db.org/xquery/markdown";
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
 
 declare namespace atom="http://www.w3.org/2005/Atom";
@@ -101,7 +101,7 @@ declare function atomic:get-content($content as element(atom:content)?, $eval as
                         xs:anyURI($path)
                     case "markdown" return
                         let $text := util:binary-to-string(util:binary-doc($path))
-                        let $parsed := md:parse($text, ($md:HTML-CONFIG, $atomic:MD_CONFIG))
+                        let $parsed := markdown:parse($text)
                         return
                             <div>{$parsed}</div>
                     default return
@@ -111,7 +111,7 @@ declare function atomic:get-content($content as element(atom:content)?, $eval as
                 case "html" case "xhtml" return
                     $content/*
                 case "markdown" return
-                    <div>{md:parse($content/string(), ($md:HTML-CONFIG, $atomic:MD_CONFIG))}</div>
+                    <div>{markdown:parse($content/string())}</div>
                 default return
                     $content/node()
     return

--- a/src/main/xar-resources/modules/config.xqm
+++ b/src/main/xar-resources/modules/config.xqm
@@ -12,7 +12,7 @@ declare namespace wiki="http://exist-db.org/xquery/wiki";
 declare namespace repo="http://exist-db.org/xquery/repo";
 declare namespace expath="http://expath.org/ns/pkg";
 declare namespace atom="http://www.w3.org/2005/Atom";
-declare namespace templates="http://exist-db.org/xquery/templates";
+declare namespace templates="http://exist-db.org/xquery/html-templating";
 
 declare variable $config:default-user := ("editor", "editor");
 declare variable $config:default-group := "biblio.users";

--- a/src/main/xar-resources/modules/extensions.xql
+++ b/src/main/xar-resources/modules/extensions.xql
@@ -3,7 +3,7 @@ xquery version "3.0";
 module namespace ext="http://atomic.exist-db.org/xquery/extensions";
 
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
-import module namespace templates="http://exist-db.org/xquery/templates";
+import module namespace templates="http://exist-db.org/xquery/html-templating";
 
 declare namespace atom="http://www.w3.org/2005/Atom";
 
@@ -37,7 +37,7 @@ declare
 function ext:code($node as node(), $model as map(*), $lang as xs:string?, $edit as xs:string, $action as xs:string?) {
     let $syntax := $lang
     let $source := replace($node/string(), "^\s*(.*)\s*$", "$1")
-    let $eXideLink := templates:link-to-app("http://exist-db.org/apps/eXide", "index.html?snip=" || encode-for-uri($source))
+    let $eXideLink := $model?eXide || "/index.html?snip=" || encode-for-uri($source)
     return
         switch ($action)
             case "edit" return

--- a/src/main/xar-resources/modules/gallery.xql
+++ b/src/main/xar-resources/modules/gallery.xql
@@ -4,7 +4,7 @@ module namespace gallery="http://exist-db.org/apps/wiki/gallery";
 
 import module namespace console="http://exist-db.org/xquery/console" at "java:org.exist.console.xquery.ConsoleModule";
 import module namespace dbutil="http://exist-db.org/xquery/dbutil" at "xmldb:exist:///db/apps/shared-resources/content/dbutils.xql";
-import module namespace templates="http://exist-db.org/xquery/templates";
+import module namespace templates="http://exist-db.org/xquery/html-templating";
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
 import module namespace theme="http://atomic.exist-db.org/xquery/atomic/theme" at "themes.xql";
 import module namespace atomic="http://atomic.exist-db.org/xquery/atomic" at "atomic.xql";

--- a/src/main/xar-resources/modules/search.xql
+++ b/src/main/xar-resources/modules/search.xql
@@ -8,7 +8,7 @@ import module namespace config="http://exist-db.org/xquery/apps/config" at "conf
 
 import module namespace kwic="http://exist-db.org/xquery/kwic";
 
-import module namespace templates="http://exist-db.org/xquery/templates";
+import module namespace templates="http://exist-db.org/xquery/html-templating";
 
 declare namespace atom="http://www.w3.org/2005/Atom";
 declare namespace html="http://www.w3.org/1999/xhtml";

--- a/src/main/xar-resources/modules/themes.xql
+++ b/src/main/xar-resources/modules/themes.xql
@@ -3,7 +3,7 @@ xquery version "3.0";
 module namespace theme="http://atomic.exist-db.org/xquery/atomic/theme";
 
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
-import module namespace templates="http://exist-db.org/xquery/templates";
+import module namespace templates="http://exist-db.org/xquery/html-templating";
 
 declare variable $theme:feed-collection := "_theme";
 

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -22,6 +22,7 @@
 
     <dependency processor="http://exist-db.org" semver-min="${exist.version}"/>
     <dependency package="http://exist-db.org/apps/shared"/>
+    <dependency package="http://exist-db.org/html-templating"/>
     <dependency package="http://exist-db.org/apps/markdown" semver-min="0.2"/>
 
     <target>${package-abbrev}</target>


### PR DESCRIPTION
Fixes maven build errors and eliminates calls to legacy templating module. 

This doesn't fix the markdown parsing problems (https://github.com/eXist-db/exist-markdown/issues/8 is still open) but is needed to facilitate the integration.